### PR TITLE
NewUI theme key added

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ If the theme is not applied to your editor, please check Settings/Editor/Color S
   
 [Intellij Plugin Repository](https://plugins.jetbrains.com/plugin/19291-github-dark) | [Report an issue](https://github.com/toby-j/Intellij_GitHub_Dark_Theme/issues)  
 
-![Screenshot](/screenshots/7-small.png)
+![Screenshot](screenshots/7-small.png)
 
-![Screenshot](/screenshots/8-small.png)
+![Screenshot](screenshots/8-small.png)

--- a/resources/themes/dark/github_dark.theme.json
+++ b/resources/themes/dark/github_dark.theme.json
@@ -11,7 +11,8 @@
     "foregroundColor": "#e6edf3",
     "notificationBackground": "#3d424b",
     "selectionBackground": "#161b22",
-    "selectionForeground": "#f0f6fc"
+    "selectionForeground": "#f0f6fc",
+    "activeTabBackground": "#161b22"
   },
   "ui": {
     "*": {
@@ -118,7 +119,7 @@
     "DefaultTabs": {
       "underlineColor": "accentColor",
       "inactiveUnderlineColor": "#4269b9",
-      "hoverBackground": "#161b22"
+      "hoverBackground": "activeTabBackground"
     },
 
     "DragAndDrop": {
@@ -138,7 +139,7 @@
     "EditorPane.inactiveBackground": "#21262d",
 
     "EditorTabs": {
-      "underlinedTabBackground": "#3d424b"
+      "underlinedTabBackground": "activeTabBackground"
     },
 
     "FileColor": {
@@ -177,6 +178,16 @@
 
     "MainToolbar": {
       "background": "backgroundColor"
+    },
+
+    "MainWindow.Tab": {
+      "borderColor": "backgroundColor",
+      "foreground": "#768599",
+      "background": "backgroundColor",
+      "hoverBackground": "activeTabBackground",
+      "selectedForeground": "foregroundColor",
+      "selectedBackground": "activeTabBackground",
+      "selectedInactiveBackground": "activeTabBackground"
     },
 
     "MemoryIndicator": {

--- a/resources/themes/dark_dimmed/github_dark_dimmed.theme.json
+++ b/resources/themes/dark_dimmed/github_dark_dimmed.theme.json
@@ -11,7 +11,8 @@
     "foregroundColor": "#cdd9e5",
     "notificationBackground": "#2d333b",
     "selectionBackground": "#161b22",
-    "selectionForeground": "#f0f6fc"
+    "selectionForeground": "#f0f6fc",
+    "activeTabBackground": "#2d333b"
   },
   "ui": {
     "*": {
@@ -102,7 +103,7 @@
     "DefaultTabs": {
       "underlineColor": "accentColor",
       "inactiveUnderlineColor": "#4269b9",
-      "hoverBackground": "#161b22"
+      "hoverBackground": "activeTabBackground"
     },
     "DragAndDrop": {
       "areaForeground": "#cdd9e5",
@@ -118,7 +119,7 @@
     },
     "EditorPane.inactiveBackground": "#21262d",
     "EditorTabs": {
-      "underlinedTabBackground": "#2d333b"
+      "underlinedTabBackground": "backgroundColor"
     },
     "FileColor": {
       "Yellow": "#3d3026",
@@ -151,6 +152,15 @@
     },
     "MainToolbar": {
       "background": "#2d333b"
+    },
+    "MainWindow.Tab": {
+      "borderColor": "backgroundColor",
+      "foreground": "#768599",
+      "background": "backgroundColor",
+      "hoverBackground": "activeTabBackground",
+      "selectedForeground": "foregroundColor",
+      "selectedBackground": "activeTabBackground",
+      "selectedInactiveBackground": "activeTabBackground"
     },
     "MemoryIndicator": {
       "allocatedBackground": "#304676",


### PR DESCRIPTION
`MainWindow.Tab` theme key added, plus minor color adjustment have been made.

Please take a look:

## GitHub Dark

### Before

<img width="1422" alt="Screenshot 2024-01-04 at 21 45 51" src="https://github.com/toby-j/jetbrains-github-dark-theme/assets/1047425/091f9ba9-5ca5-49eb-8cd5-7ec9942c8b97">

### After

<img width="1422" alt="Screenshot 2024-01-04 at 21 45 54" src="https://github.com/toby-j/jetbrains-github-dark-theme/assets/1047425/28890c83-3f33-425b-aa31-f0f5c0619e92">

## GitHub Dark Dimmed

### Before

<img width="1422" alt="Screenshot 2024-01-04 at 21 39 02" src="https://github.com/toby-j/jetbrains-github-dark-theme/assets/1047425/c6e55a75-cd15-4e60-8385-cd2a3187adca">

### After

<img width="1422" alt="Screenshot 2024-01-04 at 21 39 12" src="https://github.com/toby-j/jetbrains-github-dark-theme/assets/1047425/55b15f99-f7db-4d26-b20b-9399bf04d129">
