### PR TITLE
Improve visibility of inactive Project View selection in GitHub Dark theme

### DIFF
--- a/resources/themes/dark/github_dark.theme.json
+++ b/resources/themes/dark/github_dark.theme.json
@@ -173,7 +173,9 @@
 
     "List": {
       "selectionBackground": "#2f81f7",
-      "selectionForeground": "#ffffff"
+      "selectionForeground": "#ffffff",
+      "selectionInactiveBackground": "#294C80",
+      "selectionInactiveForeground": "#E6E6E6"
     },
 
     "MainToolbar": {
@@ -401,6 +403,8 @@
     "Tree": {
       "selectionForeground": "#f0f6fc",
       "selectionBackground": "#2f81f7",
+      "selectionInactiveForeground": "#E6E6E6",
+      "selectionInactiveBackground": "#294C80",
       "modifiedItemForeground": "accentColor",
       "rowHeight": 25,
       "rowHeight.compact": 20


### PR DESCRIPTION
## What changed
- Only `resources/themes/dark/github_dark.theme.json` was modified.
- Adjusted `Tree.selectionInactiveBackground` to `#294C80` and `Tree.selectionInactiveForeground` to `#E6E6E6`.

## Why
The previous inactive-selection background was very dark (#22272e) and offered insufficient contrast against file names. These new shades improve readability while staying distinct from the bright focused selection highlight.

### Before
![image](https://github.com/user-attachments/assets/dfe03a0c-6ba4-4828-bc64-1c7982fb44d5)


### After
![image](https://github.com/user-attachments/assets/4a024519-e0e0-49df-941c-2ec4ba60fa95)

Please let me know if you’d like any tweaks or alternate color suggestions. Thanks!